### PR TITLE
Better timestamp management

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ global:
   prefix: "huaweicloud"
   port: ":8087"
   metric_path: "/metrics"
+  retrieve_offset: "0"
+  cloudeye_timestamp: false
+  ignore_empty_datapoints: false
 
 auth:
   auth_url: "https://iam.cn-north-1.myhwclouds.com/v3"
@@ -67,6 +70,11 @@ auth:
   domain_name: "domain_name"
 
 ```
+
+Notes :
+* `global.retrieve_offset` (default "0") is an offset (example "-5m") to ask Cloudeye for some older metrics.
+* `global.cloudeye_timestamp` (default false) allows Cloudeye Exporter to send metrics with their Cloudeye timestamp
+* `global.ignore_empty_datapoints` (default false), when set, will ignore empty datapoints (no warnings)
 
 ## Prometheus Configuration
 The huaweicloud exporter needs to be passed the address as a parameter, this can be done with relabelling.

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -20,29 +20,30 @@ import (
 )
 
 type CloudAuth struct {
-	ProjectName       string `yaml:"project_name"`
-	ProjectID         string `yaml:"project_id"`
-	DomainName        string `yaml:"domain_name"`
-	AccessKey         string `yaml:"access_key"`
-	Region            string `yaml:"region"`
-	SecretKey         string `yaml:"secret_key"`
-	AuthURL           string `yaml:"auth_url"`
-	UserName          string `yaml:"user_name"`
-	Password          string `yaml:"password"`
+	ProjectName string `yaml:"project_name"`
+	ProjectID   string `yaml:"project_id"`
+	DomainName  string `yaml:"domain_name"`
+	AccessKey   string `yaml:"access_key"`
+	Region      string `yaml:"region"`
+	SecretKey   string `yaml:"secret_key"`
+	AuthURL     string `yaml:"auth_url"`
+	UserName    string `yaml:"user_name"`
+	Password    string `yaml:"password"`
 }
 
 type Global struct {
-	Port       string `yaml:"port"`
-	Prefix     string `yaml:"prefix"`
-	MetricPath string `yaml:"metric_path"`
+	Port                  string `yaml:"port"`
+	Prefix                string `yaml:"prefix"`
+	MetricPath            string `yaml:"metric_path"`
+	RetrieveOffset        string `yaml:"retrieve_offset"`
+	CloudeyeTimestamp     bool   `yaml:"cloudeye_timestamp"`
+	IgnoreEmptyDatapoints bool   `yaml:"ignore_empty_datapoints"`
 }
-
 
 type CloudConfig struct {
-	Auth               CloudAuth `yaml:"auth"`
-	Global			   Global    `yaml:"global"`
+	Auth   CloudAuth `yaml:"auth"`
+	Global Global    `yaml:"global"`
 }
-
 
 func NewCloudConfigFromFile(file string) (*CloudConfig, error) {
 	var config CloudConfig
@@ -74,6 +75,10 @@ func SetDefaultConfigValues(config *CloudConfig)  {
 
 	if config.Global.Prefix == "" {
 		config.Global.Prefix = "huaweicloud"
+	}
+
+	if config.Global.RetrieveOffset == "" {
+		config.Global.RetrieveOffset = "0"
 	}
 }
 

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -63,8 +63,7 @@ func NewCloudConfigFromFile(file string) (*CloudConfig, error) {
 	return &config, err
 }
 
-
-func SetDefaultConfigValues(config *CloudConfig)  {
+func SetDefaultConfigValues(config *CloudConfig) {
 	if config.Global.Port == "" {
 		config.Global.Port = ":8087"
 	}

--- a/main.go
+++ b/main.go
@@ -21,15 +21,14 @@ import (
 	"strings"
 
 	"github.com/huaweicloud/cloudeye-exporter/collector"
-	"github.com/prometheus/common/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/log"
 )
-
 
 var (
 	clientConfig = flag.String("config", "./clouds.yml", "Path to the cloud configuration file")
-	debug = flag.Bool("debug", false, "If debug the code.")
+	debug        = flag.Bool("debug", false, "If debug the code.")
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Hello,

This fixes 3 issues of https://github.com/huaweicloud/cloudeye-exporter/issues (9, 10 and 11) and adds a little of `go fmt`.

I added some options in the configuration file :
```
global:
...
  retrieve_offset: "0"
  cloudeye_timestamp: false
  ignore_empty_datapoints: false
...
```

Here is what I also added to the README.md file :

* `global.retrieve_offset` (default "0") is an offset (example "-5m") to ask Cloudeye for some older metrics.
* `global.cloudeye_timestamp` (default false) allows Cloudeye Exporter to send metrics with their Cloudeye timestamp
* `global.ignore_empty_datapoints` (default false), when set, will ignore empty datapoints (no warnings)
