### PR TITLE
Fix the call issues of RMS and EPS apis and make their endpoint configurable.

### DIFF
--- a/collector/config.go
+++ b/collector/config.go
@@ -60,6 +60,7 @@ func InitCloudConf(file string) error {
 		return err
 	}
 
+	initEndpointConfig()
 	return err
 }
 
@@ -174,6 +175,7 @@ func InitConfig() error {
 		conf.ProjectID = projects[0].Id
 		conf.DomainID = projects[0].DomainId
 	}
+
 	return nil
 }
 
@@ -190,4 +192,18 @@ func getProjectInfo() (*model.KeystoneListProjectsResponse, error) {
 				WithIgnoreSSLVerification(true)).
 			Build())
 	return iamclient.KeystoneListProjects(&model.KeystoneListProjectsRequest{Name: &conf.ProjectName})
+}
+
+var endpointConfig map[string]string
+
+func initEndpointConfig() {
+	context, err := ioutil.ReadFile("endpoints.yml")
+	if err != nil {
+		logs.Logger.Errorf("Init endpoint config error: &s", err.Error())
+		return
+	}
+	err = yaml.Unmarshal(context, &endpointConfig)
+	if err != nil {
+		logs.Logger.Errorf("Init endpoint config error: &s", err.Error())
+	}
 }

--- a/collector/eps.go
+++ b/collector/eps.go
@@ -7,7 +7,6 @@ import (
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/global"
 	eps "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/eps/v1"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/eps/v1/model"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/eps/v1/region"
 )
 
 var epsInfo = &EpsInfo{
@@ -24,8 +23,8 @@ const HelpInfo = `# HELP flexibleengine_epinfo flexibleengine_epinfo
 `
 
 func getEPSClient() *eps.EpsClient {
-	return eps.NewEpsClient(eps.EpsClientBuilder().WithRegion(region.ValueOf("cn-north-4")).
-		WithCredential(global.NewCredentialsBuilder().WithAk(conf.AccessKey).WithSk(conf.SecretKey).Build()).Build())
+	return eps.NewEpsClient(eps.EpsClientBuilder().WithEndpoint(getEndpoint("eps", "")).
+		WithCredential(global.NewCredentialsBuilder().WithAk(conf.AccessKey).WithSk(conf.SecretKey).WithDomainId(conf.DomainID).Build()).Build())
 }
 
 func GetEPSInfo() (string, error) {

--- a/collector/rms.go
+++ b/collector/rms.go
@@ -4,12 +4,11 @@ import (
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/global"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rms/v1"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rms/v1/model"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rms/v1/region"
 )
 
 func getRMSClient() *v1.RmsClient {
-	return v1.NewRmsClient(v1.RmsClientBuilder().WithRegion(region.ValueOf("cn-north-4")).
-		WithCredential(global.NewCredentialsBuilder().WithAk(conf.AccessKey).WithSk(conf.SecretKey).Build()).Build())
+	return v1.NewRmsClient(v1.RmsClientBuilder().WithEndpoint(getEndpoint("rms", "")).
+		WithCredential(global.NewCredentialsBuilder().WithAk(conf.AccessKey).WithSk(conf.SecretKey).WithDomainId(conf.DomainID).Build()).Build())
 }
 
 func listResources(provider, rourceType string) ([]model.ResourceEntity, error) {

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -111,6 +111,9 @@ func getMrsResourceKey(metric model.BatchMetricData) string {
 }
 
 func getEndpoint(server, version string) string {
+	if endpoint, ok := endpointConfig[server]; ok {
+		return endpoint
+	}
 	return fmt.Sprintf("https://%s/%s", strings.Replace(host, "iam", server, 1), version)
 }
 

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -1,0 +1,4 @@
+"rms":
+  "https://rms.prod-cloud-ocb.orange-business.com"
+"eps":
+  "https://eps.prod-cloud-ocb.orange-business.com"


### PR DESCRIPTION
Fix the call issues of RMS and EPS api and make their endpoint configurable.
You can change the endpoint in endpoints.yml.

This is test result,  get ecs hostname and hostIp from rms api correctly.
![image](https://github.com/FlexibleEngineCloud/cloudeye-exporter/assets/5507557/1cd4ed12-4bda-43d0-b878-b9c6d591842c)

